### PR TITLE
Update

### DIFF
--- a/0003-Some-more-icon-fixes.patch
+++ b/0003-Some-more-icon-fixes.patch
@@ -1,15 +1,15 @@
-From 039ecb4aae924509331d296ba587619a340397b6 Mon Sep 17 00:00:00 2001
-From: Ryan Gonzalez <rymg19@gmail.com>
-Date: Mon, 31 May 2021 20:17:54 -0500
-Subject: [PATCH 3/5] Some more icon fixes
+From c72636735275db3d1d0125347bf73e4b036cfe9c Mon Sep 17 00:00:00 2001
+From: bbhtt <62639087+bbhtt@users.noreply.github.com>
+Date: Tue, 24 May 2022 06:52:05 +0530
+Subject: [PATCH] Icon fixes
 
 ---
  lib/Analysis.pm | 2 +-
- lib/Icons.pm    | 3 +--
- 2 files changed, 2 insertions(+), 3 deletions(-)
+ lib/Icons.pm    | 1 -
+ 2 files changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/lib/Analysis.pm b/lib/Analysis.pm
-index 55cb8b6..643ee4c 100644
+index 50d8852..0158da8 100644
 --- a/lib/Analysis.pm
 +++ b/lib/Analysis.pm
 @@ -250,7 +250,7 @@ sub analysis_frame_one {
@@ -19,20 +19,13 @@ index 55cb8b6..643ee4c 100644
 -    my $use_image = ClamTk::Icons->get_image('edit-select');
 +    my $use_image = ClamTk::Icons->get_image('edit-find');
      $button->set_icon_name($use_image);
- 
+
      my $select_button
 diff --git a/lib/Icons.pm b/lib/Icons.pm
-index c4c2452..947776e 100644
+index b4955f3..9355d2b 100644
 --- a/lib/Icons.pm
 +++ b/lib/Icons.pm
-@@ -30,13 +30,12 @@ sub get_image() {
-     $table{ 'alarm' }                      = 'gtk-properties';
-     $table{ 'document-new' }               = 'gtk-file';
-     $table{ 'document-print' }             = 'gtk-print';
--    $table{ 'document-properties' }        = 'document-properties';
-+    $table{ 'document-properties' }        = 'gtk-properties';
-     $table{ 'document-save' }              = 'gtk-apply';
-     $table{ 'document-save-as' }           = 'gtk-save-as';
+@@ -36,7 +36,6 @@ sub get_image() {
      $table{ 'document-send' }              = 'gtk-index';
      $table{ 'edit-delete' }                = 'gtk-delete';
      $table{ 'edit-find' }                  = 'gtk-find';
@@ -40,6 +33,5 @@ index c4c2452..947776e 100644
      $table{ 'edit-undo' }                  = 'gtk-undelete';
      $table{ 'emblem-important' }           = 'gtk-no';
      $table{ 'folder-documents' }           = 'gtk-directory';
--- 
-2.31.1
-
+--
+2.36.1

--- a/0004-Update-releases-in-appdata.patch
+++ b/0004-Update-releases-in-appdata.patch
@@ -1,30 +1,33 @@
-From 46c0d9750bf1599a9823d87838fc0935291ebaca Mon Sep 17 00:00:00 2001
-From: Ryan Gonzalez <rymg19@gmail.com>
-Date: Fri, 9 Jul 2021 12:07:38 -0500
-Subject: [PATCH 4/5] Update releases in appdata
+From 6e6182a9e341f89263ba478d1f32dfb0d3a520e0 Mon Sep 17 00:00:00 2001
+From: bbhtt <bbhtt.zn0i8@slmail.me>
+Date: Sat, 29 Oct 2022 07:54:53 +0530
+Subject: [PATCH] Update releases in appdata
 
 ---
- com.github.davetheunsub.clamtk.appdata.xml | 7 ++++++-
- 1 file changed, 6 insertions(+), 1 deletion(-)
+ com.github.davetheunsub.clamtk.appdata.xml | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
 
 diff --git a/com.github.davetheunsub.clamtk.appdata.xml b/com.github.davetheunsub.clamtk.appdata.xml
-index c6d0713..47e7f00 100644
+index c6d0713..34fb81f 100644
 --- a/com.github.davetheunsub.clamtk.appdata.xml
 +++ b/com.github.davetheunsub.clamtk.appdata.xml
-@@ -88,7 +88,12 @@
+@@ -88,6 +88,16 @@
   </screenshots>
- 
+
   <releases>
--    <release version="6.12" date="2021-06-05">
++    <release version="6.14" date="2021-11-20">
++      <description>
++        <p>Hopefully a fix for context-menu scanning image issues</p>
++      </description>
++    </release>
 +    <release version="6.13" date="2021-07-07">
 +      <description>
 +        <p>Fixes for appdata.xml</p>
 +      </description>
 +    </release>
-+    <release version="6.12" date="2021-07-05">
+     <release version="6.12" date="2021-06-05">
        <description>
          <p>Bug fixes</p>
-       </description>
--- 
-2.31.1
+--
+2.38.1
 

--- a/com.gitlab.davem.ClamTk.yaml
+++ b/com.gitlab.davem.ClamTk.yaml
@@ -94,13 +94,14 @@ modules:
       - '-DENABLE_MILTER=OFF'
       - '-DENABLE_CLAMONACC=OFF'
       - '-DENABLE_TESTS=OFF'
+      - '-DENABLE_EXAMPLES=OFF'
       - '-DENABLE_SYSTEMD=OFF'
       - '-DENABLE_MAN_PAGES=OFF'
       - '-DDATABASE_DIRECTORY=/var/data/clamav'
     sources:
       - type: archive
-        url: https://www.clamav.net/downloads/production/clamav-0.105.1.tar.gz
-        sha256: d2bc16374db889a6e5a6ac40f8c6e700254a039acaa536885a09eeea4b8529f6
+        url: https://www.clamav.net/downloads/production/clamav-1.0.1.tar.gz
+        sha256: 0872dc1b82ff4cd7e8e4323faf5ee41a1f66ae80865d05429085b946355d86ee
     post-install:
       - 'sed "s/^Example/#Example/" /app/etc/freshclam.conf.sample > /app/etc/freshclam.conf'
     cleanup:

--- a/com.gitlab.davem.ClamTk.yaml
+++ b/com.gitlab.davem.ClamTk.yaml
@@ -11,7 +11,7 @@ finish-args:
   - '--filesystem=host'
   - '--share=ipc'
   - '--share=network'
-  - '--socket=x11'
+  - '--socket=fallback-x11'
   - '--socket=wayland'
 modules:
   # Based on https://github.com/flathub/io.github.Hexchat.Plugin.Perl
@@ -25,8 +25,8 @@ modules:
       ldflags: '-fpic'
     sources:
       - type: archive
-        url: https://www.cpan.org/src/5.0/perl-5.34.0.tar.gz
-        sha256: 551efc818b968b05216024fb0b727ef2ad4c100f8cb6b43fab615fa78ae5be9a
+        url: https://www.cpan.org/src/5.0/perl-5.36.0.tar.gz
+        sha256: e26085af8ac396f62add8a533c3a0ea8c8497d836f0689347ac5abd7b7a4e00a
       - type: shell
         commands:
           - 'ln -s configure{.gnu,}'
@@ -124,8 +124,8 @@ modules:
       - 'install -Dm 644 com.gitlab.davem.ClamTk.metainfo.xml -t /app/share/metainfo'
     sources:
       - type: archive
-        url: https://github.com/dave-theunsub/clamtk/releases/download/v6.13/clamtk-6.13.tar.xz
-        sha256: 91bc42b761d32c4b72a0cdb341dfe06949179796d1f4b05a22090c0047d92d58
+        url: https://github.com/dave-theunsub/clamtk/releases/download/v6.14/clamtk-6.14.tar.xz
+        sha256: 05e4755ab096b8193c5b5dbdfcf1a8524728ed35558301a32270162b24e22f84
       - type: patch
         path: 0001-Remove-some-functionality-that-doesn-t-apply-to-Flat.patch
       - type: patch

--- a/generated-sources.json
+++ b/generated-sources.json
@@ -43,9 +43,9 @@
    },
    {
       "dest": "perl-libs/JSON",
-      "sha256": "e41f8761a5e7b9b27af26fe5780d44550d7a6a66bf3078e337d676d07a699941",
+      "sha256": "df8b5143d9a7de99c47b55f1a170bd1f69f711935c186a6dc0ab56dd05758e35",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-4.03.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-4.10.tar.gz"
    },
    {
       "dest": "perl-libs/Locale-gettext",
@@ -55,33 +55,33 @@
    },
    {
       "dest": "perl-libs/Net-SSLeay",
-      "sha256": "f8696cfaca98234679efeedc288a9398fcf77176f1f515dbc589ada7c650dc93",
+      "sha256": "876d022fbc719631b11d6bb4b6e78db3c19bbca578093c376c8f9900a4432aa3",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.90.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.93_01.tar.gz"
    },
    {
       "dest": "perl-libs/Mozilla-CA",
-      "sha256": "b3ca0002310bf24a16c0d5920bdea97a2f46e77e7be3e7377e850d033387c726",
+      "sha256": "122c8900000a9d388aa8e44f911cab6c118fe8497417917a84a8ec183971b449",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/A/AB/ABH/Mozilla-CA-20200520.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/A/AB/ABH/Mozilla-CA-20211001.tar.gz"
    },
    {
       "dest": "perl-libs/IO-Socket-SSL",
-      "sha256": "40da40948ecc9c787ed39c95715872679eebfd54243721174993a2003e32ab0a",
+      "sha256": "c30ee2220b1e181a968ebbc81861d0cadf334b001377a44105ae5a8637ddae8c",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.071.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.075.tar.gz"
    },
    {
       "dest": "perl-libs/URI",
-      "sha256": "03e63ada499d2645c435a57551f041f3943970492baa3b3338246dab6f1fae0a",
+      "sha256": "4cd2752adfaddd58f54e559155578696354834ee77a7760a04089de1f338fb11",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-5.09.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-5.16.tar.gz"
    },
    {
       "dest": "perl-libs/Net-HTTP",
-      "sha256": "375aa35b76be99f06464089174d66ac76f78ce83a5c92a907bbfab18b099eec4",
+      "sha256": "62faf9a5b84235443fe18f780e69cecf057dea3de271d7d8a0ba72724458a1a2",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/Net-HTTP-6.21.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/Net-HTTP-6.22.tar.gz"
    },
    {
       "dest": "perl-libs/LWP-MediaTypes",
@@ -115,9 +115,9 @@
    },
    {
       "dest": "perl-libs/HTTP-Message",
-      "sha256": "23b967f71b852cb209ec92a1af6bac89a141dff1650d69824d29a345c1eceef7",
+      "sha256": "2183e1a8dfaef79309eae1d3902c5d9d42b516eb0a297be039862fb2aa3afa07",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Message-6.33.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Message-6.41.tar.gz"
    },
    {
       "dest": "perl-libs/HTML-Tagset",
@@ -127,9 +127,9 @@
    },
    {
       "dest": "perl-libs/HTML-Parser",
-      "sha256": "64d9e2eb2b420f1492da01ec0e6976363245b4be9290f03f10b7d2cb63fa2f61",
+      "sha256": "b934907d37b58e5b13f9b374a21e177645439ebcb44900cd37329b0c48893cdc",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTML-Parser-3.76.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTML-Parser-3.79.tar.gz"
    },
    {
       "dest": "perl-libs/WWW-RobotRules",
@@ -145,15 +145,15 @@
    },
    {
       "dest": "perl-libs/File-Listing",
-      "sha256": "15b3a4871e23164a36f226381b74d450af41f12cc94985f592a669fcac7b48ff",
+      "sha256": "46c4fb9f9eb9635805e26b7ea55b54455e47302758a10ed2a0b92f392713770c",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/File-Listing-6.14.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/File-Listing-6.15.tar.gz"
    },
    {
       "dest": "perl-libs/Try-Tiny",
-      "sha256": "da5bd0d5c903519bbf10bb9ba0cb7bcac0563882bcfe4503aee3fb143eddef6b",
+      "sha256": "3300d31d8a4075b26d8f46ce864a1d913e0e8467ceeba6655d5d2b2e206c11be",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Try-Tiny-0.30.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Try-Tiny-0.31.tar.gz"
    },
    {
       "dest": "perl-libs/HTTP-Cookies",
@@ -163,9 +163,9 @@
    },
    {
       "dest": "perl-libs/libwww-perl",
-      "sha256": "c1d0d3a44a039b136ebac7336f576e3f5c232347e8221abd69ceb4108e85c920",
+      "sha256": "96eec40a3fd0aa1bd834117be5eb21c438f73094d861a1a7e5774f0b1226b723",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/libwww-perl-6.55.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/libwww-perl-6.67.tar.gz"
    },
    {
       "dest": "perl-libs/LWP-Protocol-https",
@@ -175,9 +175,9 @@
    },
    {
       "dest": "perl-libs/Text-CSV",
-      "sha256": "2a90a5eea3f22c40b87932a929621680609ab5f6b874a77c4134c8a04eb8e74b",
+      "sha256": "84120de3e10489ea8fbbb96411a340c32cafbe5cdff7dd9576b207081baa9d24",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/Text-CSV-2.01.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/Text-CSV-2.02.tar.gz"
    },
    {
       "commands": [

--- a/generated-sources.json
+++ b/generated-sources.json
@@ -55,9 +55,9 @@
    },
    {
       "dest": "perl-libs/Net-SSLeay",
-      "sha256": "876d022fbc719631b11d6bb4b6e78db3c19bbca578093c376c8f9900a4432aa3",
+      "sha256": "1a11d1ae63e9fc85c90279085957aec81a15af985d7cff185b66154f7032fcdf",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.93_01.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.93_02.tar.gz"
    },
    {
       "dest": "perl-libs/Mozilla-CA",
@@ -67,15 +67,15 @@
    },
    {
       "dest": "perl-libs/IO-Socket-SSL",
-      "sha256": "c30ee2220b1e181a968ebbc81861d0cadf334b001377a44105ae5a8637ddae8c",
+      "sha256": "07bdf826a8d6b463316d241451c890d1012fa2499a83d8e3d00ce0a584618443",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.075.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.081.tar.gz"
    },
    {
       "dest": "perl-libs/URI",
-      "sha256": "4cd2752adfaddd58f54e559155578696354834ee77a7760a04089de1f338fb11",
+      "sha256": "5f7e42b769cb27499113cfae4b786c37d49e7c7d32dbb469602cd808308568f8",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-5.16.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-5.17.tar.gz"
    },
    {
       "dest": "perl-libs/Net-HTTP",
@@ -115,9 +115,9 @@
    },
    {
       "dest": "perl-libs/HTTP-Message",
-      "sha256": "2183e1a8dfaef79309eae1d3902c5d9d42b516eb0a297be039862fb2aa3afa07",
+      "sha256": "398b647bf45aa972f432ec0111f6617742ba32fc773c6612d21f64ab4eacbca1",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Message-6.41.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Message-6.44.tar.gz"
    },
    {
       "dest": "perl-libs/HTML-Tagset",
@@ -127,9 +127,9 @@
    },
    {
       "dest": "perl-libs/HTML-Parser",
-      "sha256": "b934907d37b58e5b13f9b374a21e177645439ebcb44900cd37329b0c48893cdc",
+      "sha256": "c0910a5c8f92f8817edd06ccfd224ba1c2ebe8c10f551f032587a1fc83d62ff2",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTML-Parser-3.79.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTML-Parser-3.81.tar.gz"
    },
    {
       "dest": "perl-libs/WWW-RobotRules",
@@ -163,9 +163,9 @@
    },
    {
       "dest": "perl-libs/libwww-perl",
-      "sha256": "96eec40a3fd0aa1bd834117be5eb21c438f73094d861a1a7e5774f0b1226b723",
+      "sha256": "42784a5869855ee08522dfb1d30fccf98ca4ddefa8c6c1bcb0d68a0adceb7f01",
       "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/libwww-perl-6.67.tar.gz"
+      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/libwww-perl-6.68.tar.gz"
    },
    {
       "dest": "perl-libs/LWP-Protocol-https",

--- a/generated-sources.json
+++ b/generated-sources.json
@@ -180,6 +180,12 @@
       "url": "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/Text-CSV-2.02.tar.gz"
    },
    {
+      "dest": "perl-libs/Clone",
+      "sha256": "aadeed5e4c8bd6bbdf68c0dd0066cb513e16ab9e5b4382dc4a0aafd55890697b",
+      "type": "archive",
+      "url": "https://www.cpan.org/modules/by-module/Clone/Clone-0.46.tar.gz"
+   },
+   {
       "commands": [
          "set -e",
          "function make_install {",
@@ -223,7 +229,8 @@
          "(make_install perl-libs/HTTP-Cookies)",
          "(make_install perl-libs/libwww-perl)",
          "(make_install perl-libs/LWP-Protocol-https)",
-         "(make_install perl-libs/Text-CSV)"
+         "(make_install perl-libs/Text-CSV)",
+         "(make_install perl-libs/Clone)"
       ],
       "dest": "perl-libs",
       "dest-filename": "install.sh",


### PR DESCRIPTION
~I wanted to update ClamAV to 0.105 as well but >=0.104 requires Rust and changed the buildsystem to cmake, also requires some new dependencies. That will require some work, I will see if I can do that in a later PR.~ Done in https://github.com/flathub/com.gitlab.davem.ClamTk/pull/9

Some of the icons are gone from the main window. Other than that I didn't see any issues.

The screenshot file here should no longer be required and wasn't being used, it should be removed

Fixes https://github.com/flathub/com.gitlab.davem.ClamTk/issues/7
Fixes https://github.com/flathub/com.gitlab.davem.ClamTk/issues/6

cc @refi64