### PR TITLE
Update clamav to 1.1.1

### DIFF
--- a/com.gitlab.davem.ClamTk.yaml
+++ b/com.gitlab.davem.ClamTk.yaml
@@ -100,8 +100,8 @@ modules:
       - '-DDATABASE_DIRECTORY=/var/data/clamav'
     sources:
       - type: archive
-        url: https://www.clamav.net/downloads/production/clamav-1.0.1.tar.gz
-        sha256: 0872dc1b82ff4cd7e8e4323faf5ee41a1f66ae80865d05429085b946355d86ee
+        url: https://www.clamav.net/downloads/production/clamav-1.1.1.tar.gz
+        sha256: a26699704bb4ddf2684e4adc1f46d5f3de9a9a8959f147970f969cc32b2f0d9e
     post-install:
       - 'sed "s/^Example/#Example/" /app/etc/freshclam.conf.sample > /app/etc/freshclam.conf'
     cleanup:


### PR DESCRIPTION
1.0.1 is affected by [CVE-2023-20197](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20197)

https://github.com/Cisco-Talos/clamav/releases/tag/clamav-1.1.1

I think there should be a x-checker for this.